### PR TITLE
部分机器不能运行VBS脚本,使用bat脚本

### DIFF
--- a/mixly_arduino/Mixly.bat
+++ b/mixly_arduino/Mixly.bat
@@ -1,0 +1,1 @@
+start .\arduino-1.7.9\java\bin\javaw -jar Mixly.jar


### PR DESCRIPTION
解决问题: 部分机器不能运行VBS脚本. 有安全限定.
解决方式:使用start javaw 打开一样没有黑窗口.